### PR TITLE
Override hardcoded sysnumber with user input

### DIFF
--- a/Standalone/rfc/Invoke-READTABLE-via-GEN_PROXY.ps1
+++ b/Standalone/rfc/Invoke-READTABLE-via-GEN_PROXY.ps1
@@ -56,8 +56,7 @@
         $cfgParams = New-Object SAP.Middleware.Connector.RfcConfigParameters
         $cfgParams.Add("NAME", "TEST")
         $cfgParams.Add("ASHOST", $target)
-       # systemnumber is by default 00 
-        $cfgParams.Add("SYSNR", "00")
+        $cfgParams.Add("SYSNR", $sysnr)
         $cfgParams.Add("CLIENT", $client)
         $cfgParams.Add("USER", $username)
         $cfgParams.Add("PASSWD", $password)

--- a/Standalone/rfc/Invoke-RFC_PING.ps1
+++ b/Standalone/rfc/Invoke-RFC_PING.ps1
@@ -55,7 +55,6 @@
         $cfgParams = New-Object SAP.Middleware.Connector.RfcConfigParameters
         $cfgParams.Add("NAME", "TEST")
         $cfgParams.Add("ASHOST", $target)
-       # systemnumber is by default 00 
         $cfgParams.Add("SYSNR", $sysnr)
         $cfgParams.Add("CLIENT", $client)
         $cfgParams.Add("USER", $username)

--- a/Standalone/rfc/Invoke-RFC_PING.ps1
+++ b/Standalone/rfc/Invoke-RFC_PING.ps1
@@ -56,7 +56,7 @@
         $cfgParams.Add("NAME", "TEST")
         $cfgParams.Add("ASHOST", $target)
        # systemnumber is by default 00 
-        $cfgParams.Add("SYSNR", "00")
+        $cfgParams.Add("SYSNR", $sysnr)
         $cfgParams.Add("CLIENT", $client)
         $cfgParams.Add("USER", $username)
         $cfgParams.Add("PASSWD", $password)

--- a/Standalone/rfc/Invoke-RFC_SYSTEM_INFO.ps1
+++ b/Standalone/rfc/Invoke-RFC_SYSTEM_INFO.ps1
@@ -55,8 +55,7 @@
         $cfgParams = New-Object SAP.Middleware.Connector.RfcConfigParameters
         $cfgParams.Add("NAME", "TEST")
         $cfgParams.Add("ASHOST", $target)
-       # systemnumber is by default 00 
-        $cfgParams.Add("SYSNR", "00")
+        $cfgParams.Add("SYSNR", $sysnr)
         $cfgParams.Add("CLIENT", $client)
         $cfgParams.Add("USER", $username)
         $cfgParams.Add("PASSWD", $password)

--- a/Standalone/rfc/Invoke-RFC_bruteforce.ps1
+++ b/Standalone/rfc/Invoke-RFC_bruteforce.ps1
@@ -36,8 +36,7 @@
         $cfgParams = New-Object SAP.Middleware.Connector.RfcConfigParameters
         $cfgParams.Add("NAME", "TEST")
         $cfgParams.Add("ASHOST", $target)
-       # systemnumber is by default 00 
-        $cfgParams.Add("SYSNR", "00")
+        $cfgParams.Add("SYSNR", $sysnr)
         $cfgParams.Add("CLIENT", $client)
         $cfgParams.Add("USER", $username)
         $cfgParams.Add("PASSWD", $password)

--- a/Standalone/rfc/Invoke-skeleton.ps1
+++ b/Standalone/rfc/Invoke-skeleton.ps1
@@ -54,8 +54,7 @@
         $cfgParams = New-Object SAP.Middleware.Connector.RfcConfigParameters
         $cfgParams.Add("NAME", "TEST")
         $cfgParams.Add("ASHOST", $target)
-       # systemnumber is by default 00 
-        $cfgParams.Add("SYSNR", "00")
+        $cfgParams.Add("SYSNR", $sysnr)
         $cfgParams.Add("CLIENT", $client)
         $cfgParams.Add("USER", $username)
         $cfgParams.Add("PASSWD", $password)


### PR DESCRIPTION
Changed the RFC scripts to use the sysnr from the parameter value instead of defaulting to "00".